### PR TITLE
Fix homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 About bluesky-kafka
 ===================
 
-Home: https://github.com/NSLS-II/bluesky-kafka
+Home: https://github.com/bluesky/bluesky-kafka
 
-Package license: BSD
+Package license: BSD-3-Clause
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -29,7 +29,7 @@ test:
     - bluesky_kafka
 
 about:
-  home: https://github.com/NSLS-II/bluesky-kafka
-  license: BSD
+  home: https://github.com/bluesky/bluesky-kafka
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: The bluesky-kafka module


### PR DESCRIPTION
This resolves the confusion about the old and new `bluesky-kafka` repos from the NSLS-II and bluesky GH orgs correspondingly. See https://github.com/bluesky/bluesky-kafka/issues/5 for details.